### PR TITLE
Bumped SonarQube Analysis Version to v6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,6 @@ jobs:
           name: coverage-report
           path: .coverage-reports/coverage.xml
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5.3.1
+        uses: SonarSource/sonarqube-scan-action@v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
This PR bumps the SonarQube version to v6.0.0 in response to the dependabot vulnerability flag that came up recently:

https://github.com/proveskit/pysquared/security/dependabot/1
